### PR TITLE
Painting metatileentity with material rgb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added casings, walls and coils orePrefix material blocks generated *via* a `MaterialFlag` ([#26](https://github.com/tekcay/tkcy-simple-addon/pull/26))
 
 ### Internal changes
+- added an interface for using unpainted `BlockMaterial` in MetaTileEntities ([#39](https://github.com/tekcay/tkcy-simple-addon/pull/39))
 - updated GTCEu dependency from 2.8.6 to 2.8.8 ([#37](https://github.com/tekcay/tkcy-simple-addon/pull/37))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - added casings, walls and coils orePrefix material blocks generated *via* a `MaterialFlag` ([#26](https://github.com/tekcay/tkcy-simple-addon/pull/26))
 
 ### Internal changes
-- added an interface for using unpainted `BlockMaterial` in MetaTileEntities ([#39](https://github.com/tekcay/tkcy-simple-addon/pull/39))
+- added an interface for using unpainted `BlockMaterial` in MetaTileEntities ([#40](https://github.com/tekcay/tkcy-simple-addon/pull/40))
 - updated GTCEu dependency from 2.8.6 to 2.8.8 ([#37](https://github.com/tekcay/tkcy-simple-addon/pull/37))
 
 

--- a/src/main/java/tkcy/simpleaddon/api/metatileentities/BlockMaterialMetaTileEntityPaint.java
+++ b/src/main/java/tkcy/simpleaddon/api/metatileentities/BlockMaterialMetaTileEntityPaint.java
@@ -1,0 +1,15 @@
+package tkcy.simpleaddon.api.metatileentities;
+
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.unification.material.Material;
+
+/**
+ * To remind to override {@link MetaTileEntity#getPaintingColorForRendering()} by
+ * {@code return getPaintingColorForRendering(Material} material)
+ */
+public interface BlockMaterialMetaTileEntityPaint {
+
+    default int getPaintingColorForRendering(Material material) {
+        return material.getMaterialRGB();
+    }
+}

--- a/src/main/java/tkcy/simpleaddon/api/render/TKCYSATextures.java
+++ b/src/main/java/tkcy/simpleaddon/api/render/TKCYSATextures.java
@@ -1,5 +1,6 @@
 package tkcy.simpleaddon.api.render;
 
+import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.relauncher.Side;
 
@@ -13,6 +14,9 @@ import tkcy.simpleaddon.TekCaySimpleAddon;
 public class TKCYSATextures {
 
     public static OrientedOverlayRenderer ROLLING_MILL_OVERLAY = new OrientedOverlayRenderer("machines/rolling_mill");
+    public static SimpleOverlayRenderer WALL_TEXTURE = new SimpleOverlayRenderer("material_sets/dull/wall");
+    public static SimpleOverlayRenderer CASING_TEXTURE = new SimpleOverlayRenderer("material_sets/dull/casing");
+    public static SimpleOverlayRenderer COIL_TEXTURE = new SimpleOverlayRenderer("material_sets/dull/coil");
 
     public static void preInit() {
         // ROLLING_MILL_OVERLAY = new OrientedOverlayRenderer("machines/rolling_mill");


### PR DESCRIPTION
This PR just adds the `BlockMaterialMetaTileEntityPaint` interface as an optional simple helper.  It provides a simple  method that just returns a `Material` colourRGB. This allows painting registered overlayRenderers depending of a material colour. This means that creating metatileentities which rendering uses the same texture but painted with the material colour only needs one single texture. 
~~(might sound redundant or unclear, time will tell)~~


A typical implementation would consist in overriding the `getBaseTexture()` in a `MetaTileEntity` :

```java
    @SideOnly(Side.CLIENT)
    @Override
    public ICubeRenderer getBaseTexture(IMultiblockPart sourcePart) {
        return <an overlay renderer>;
    }
```
in which the renderer is a simple white texture.


Then the `getPaintingColorForRendering()` method is overriden as it is used in metatileentity rendering (`renderMetaTileEntity()`) :

```java
    @Override
    @SideOnly(Side.CLIENT)
    public int getPaintingColorForRendering() {
        return getPaintingColorForRendering(<a material>);
    }
```
in which `getPaintingColorForRendering(Material material)` from the interface is just `material.getMaterialRGB()`.
